### PR TITLE
Expicitly declare that the build process needs to run commands as root

### DIFF
--- a/hadoop_hive_spark_docker/hue/Dockerfile
+++ b/hadoop_hive_spark_docker/hue/Dockerfile
@@ -2,6 +2,8 @@ FROM gethue/hue:latest
 
 MAINTAINER Aditya Pal <aditya.pal.science@gmail.com>
 
+USER root
+
 ADD configs/hue.ini /usr/share/hue/desktop/conf/hue.ini
 ADD configs/hue.ini /usr/share/hue/desktop/conf/hue-overrides.ini 
 ADD configs/hue.ini /usr/share/hue/tools/docker/hue/conf/hue-overrides.ini


### PR DESCRIPTION
When building hue image with docker as a non-root user, the building process encountered an error: mkdir does not have the permission to create the directory. This commit fixes it.